### PR TITLE
Use existing sections

### DIFF
--- a/netpyne/cell.py
+++ b/netpyne/cell.py
@@ -525,7 +525,7 @@ class Cell (object):
         plasticity = params.get('plasticity')
         if plasticity and sim.cfg['createNEURONObj']:
             try:
-                plastSection = h.Section()
+                plastSection = self.secs['soma']['hSection']
                 plastMech = getattr(h, plasticity['mech'], None)(0, sec=plastSection)  # create plasticity mechanism (eg. h.STDP)
                 for plastParamName,plastParamValue in plasticity['params'].iteritems():  # add params of the plasticity mechanism
                     setattr(plastMech, plastParamName, plastParamValue)


### PR DESCRIPTION
Currently, netpyne creates a new `h.Section()` for every plastic synapse -- effectively creating a sim with as many cells as there are synapses!! So for a sim with 200 cells and 6000 plastic synapses, this fix makes the sim run 30x faster.