### PR TITLE
removed instances of mutable objects in function definitions

### DIFF
--- a/netpyne/analysis.py
+++ b/netpyne/analysis.py
@@ -468,7 +468,7 @@ def plotSpikeHist (include = ['allCells', 'eachPop'], timeRange = None, binSize 
 ######################################################################################################################################################
 ## Plot recorded cell traces (V, i, g, etc.)
 ######################################################################################################################################################
-def plotTraces (include = [], timeRange = None, overlay = False, oneFigPer = 'cell', rerun = False,
+def plotTraces (include = None, timeRange = None, overlay = False, oneFigPer = 'cell', rerun = False,
     figSize = (10,8), saveData = None, saveFig = None, showFig = True): 
     ''' 
     Plot recorded traces
@@ -490,6 +490,8 @@ def plotTraces (include = [], timeRange = None, overlay = False, oneFigPer = 'ce
     '''
 
     print('Plotting recorded cell traces ...')
+
+    if include is None: include = [] # If not defined, initialize as empty list
 
     # rerun simulation so new include cells get recorded from
     if rerun: 

--- a/netpyne/simFuncs.py
+++ b/netpyne/simFuncs.py
@@ -30,7 +30,9 @@ import sim, specs
 ###############################################################################
 # initialize variables and MPI
 ###############################################################################
-def initialize (netParams = {}, simConfig = {}, net = None):
+def initialize (netParams = None, simConfig = None, net = None):
+	if netParams is None: netParams = {} # If not specified, initialize as empty dict
+	if simConfig is None: simConfig = {} # If not specified, initialize as empty dict
     if hasattr(simConfig, 'popParams') or hasattr(netParams, 'duration'):
         print 'Error: seems like the sim.initialize() arguments are in the wrong order, try initialize(netParams, simConfig)'
         sys.exit()

--- a/netpyne/specs.py
+++ b/netpyne/specs.py
@@ -265,49 +265,57 @@ class NetParams (object):
 			for k,v in netParamsDict.iteritems(): 
 				setattr(self, k, v)
 
-	def addCellParams(self, label=None, params={}):
+	def addCellParams(self, label=None, params=None):
+		if params is None: params = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1
 		self.cellParams[label] = Dict(params)
 
-	def addPopParams(self, label=None, params={}):
+	def addPopParams(self, label=None, params=None):
+		if params is None: params = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1
 		self.popParams[label] = Dict(params)
 
-	def addSynMechParams(self, label=None, params={}):
+	def addSynMechParams(self, label=None, params=None):
+		if params is None: params = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1
 		self.synMechParams[label] = Dict(params)
 
-	def addConnParams(self, label=None, params={}):
+	def addConnParams(self, label=None, params=None):
+		if params is None: params = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1
 		self.connParams[label] = Dict(params)
 
-	def addSubConnParams(self, label=None, params={}):
+	def addSubConnParams(self, label=None, params=None):
+		if params is None: params = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1
 		self.subConnParams[label] = Dict(params)
 
-	def addStimSourceParams(self, label=None, params={}):
+	def addStimSourceParams(self, label=None, params=None):
+		if params is None: params = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1
 		self.stimSourceParams[label] = Dict(params)
 
-	def addStimTargetParams(self, label=None, params={}):
+	def addStimTargetParams(self, label=None, params=None):
+		if params is None: params = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1
 		self.stimTargetParams[label] = Dict(params)
 
-	def importCellParams(self, label, conds, fileName, cellName, cellArgs={}, importSynMechs=False):
+	def importCellParams(self, label, conds, fileName, cellName, cellArgs=None, importSynMechs=False):
+		if cellArgs is None: cellArgs = {}
 		if not label: 
 			label = int(self._labelid)
 			self._labelid += 1

--- a/netpyne/utils.py
+++ b/netpyne/utils.py
@@ -8,7 +8,8 @@ Contributors: salvadordura@gmail.com
 import os, sys
 from neuron import h
 
-def getSecName (sec, dirCellSecNames = {}):
+def getSecName (sec, dirCellSecNames = None):
+	if dirCellSecNames is None: dirCellSecNames = {}
     if '>.' in sec.name():
         fullSecName = sec.name().split('>.')[1] 
     elif '.' in sec.name():
@@ -76,8 +77,10 @@ def _equal_dicts (d1, d2, ignore_keys):
             return False
     return True
 
-def importCell (fileName, cellName, cellArgs = []):
+def importCell (fileName, cellName, cellArgs = None):
     h.initnrn()
+
+    if cellArgs is None: cellArgs = [] # Define as empty list if not otherwise defined
 
     ''' Import cell from HOC template or python file into framework format (dict of sections, with geom, topol, mechs, syns)'''
     if fileName.endswith('.hoc'):


### PR DESCRIPTION
Stupidly, Python intializes mutables when a function is defined, not when called -- so `def foo(a=0)` is fine, but `def foo(a=[])` is not. For more info:
https://pythonconquerstheuniverse.wordpress.com/2012/02/15/mutable-default-arguments/