### PR TITLE
In cell.py, now if mechParamValue is a single-item list, it uses that…

### DIFF
--- a/netpyne/cell.py
+++ b/netpyne/cell.py
@@ -418,7 +418,10 @@ class CompartCell (Cell):
                         mechParamValueFinal = mechParamValue
                         for iseg,seg in enumerate(sec['hSec']):  # set mech params for each segment
                             if type(mechParamValue) in [list]: 
-                                mechParamValueFinal = mechParamValue[iseg]
+                                if len(mechParamValue) == 1: 
+                                    mechParamValueFinal = mechParamValue[0]
+                                else:
+                                    mechParamValueFinal = mechParamValue[iseg]
                             if mechParamValueFinal is not None:  # avoid setting None values
                                 setattr(getattr(seg, mechName), mechParamName,mechParamValueFinal)
                             


### PR DESCRIPTION
… value for all segs in sec (used to be if mechParamValue was a list, it had to be the length of the number of secs).