### PR TITLE
Py3 pickle compatibility

### DIFF
--- a/netpyne/simFuncs.py
+++ b/netpyne/simFuncs.py
@@ -399,8 +399,11 @@ def _loadFile (filename):
     if ext == 'pkl':
         import pickle
         print('Loading file %s ... ' % (filename))
-        with open(filename, 'r') as fileObj:
-            data = pickle.load(fileObj)
+        with open(filename, 'rb') as fileObj:
+            if sys.version_info[0] == 2:
+                data = pickle.load(fileObj)
+            else:
+                data = pickle.load(fileObj, encoding='latin1')
 
     # load dpk file
     elif ext == 'dpk':

--- a/netpyne/specs.py
+++ b/netpyne/specs.py
@@ -7,7 +7,6 @@ Contributors: salvadordura@gmail.com
 
 from collections import OrderedDict
 from netpyne import utils
-import sys
 
 ###############################################################################
 # Dict class (allows dot notation for dicts)

--- a/netpyne/specs.py
+++ b/netpyne/specs.py
@@ -7,6 +7,7 @@ Contributors: salvadordura@gmail.com
 
 from collections import OrderedDict
 from netpyne import utils
+import sys
 
 ###############################################################################
 # Dict class (allows dot notation for dicts)
@@ -645,8 +646,14 @@ class NetParams (object):
             print 'Error adding weightNorm: netParams.cellParams does not contain %s' % (label)
             return
 
-        with open(fileName, 'r') as fileObj:
-            weightNorm = pickle.load(fileObj)
+        # with open(fileName, 'r') as fileObj:
+        #     weightNorm = pickle.load(fileObj)
+
+        with open(fileName, 'rb') as fileObj:
+            if sys.version_info[0] == 2:
+                weightNorm = pickle.load(fileObj)
+            else:
+                weightNorm = pickle.load(fileObj, encoding='latin1')
 
         try:
             somaSec = next((k for k in weightNorm.keys() if k.startswith('soma')),None)

--- a/netpyne/specs.py
+++ b/netpyne/specs.py
@@ -639,15 +639,12 @@ class NetParams (object):
 
 
     def addCellParamsWeightNorm(self, label, fileName, threshold=1000):
-        import pickle
+        import pickle, sys
         if label in self.cellParams:
             cellRule = self.cellParams[label]
         else:
             print 'Error adding weightNorm: netParams.cellParams does not contain %s' % (label)
             return
-
-        # with open(fileName, 'r') as fileObj:
-        #     weightNorm = pickle.load(fileObj)
 
         with open(fileName, 'rb') as fileObj:
             if sys.version_info[0] == 2:
@@ -679,7 +676,7 @@ class NetParams (object):
             return
 
         if ext == 'pkl':
-            with open(fileName, 'w') as fileObj:
+            with open(fileName, 'wb') as fileObj:
                 pickle.dump(cellRule, fileObj)
         elif ext == 'json':
             with open(fileName, 'w') as fileObj:
@@ -687,12 +684,15 @@ class NetParams (object):
 
 
     def loadCellParamsRule(self, label, fileName):
-        import pickle, json, os
+        import pickle, json, os, sys
 
         ext = os.path.basename(fileName).split('.')[1]
         if ext == 'pkl':
-            with open(fileName, 'r') as fileObj:
-                cellRule = pickle.load(fileObj)
+            with open(fileName, 'rb') as fileObj:
+                if sys.version_info[0] == 2:
+                    cellRule = pickle.load(fileObj)
+                else:
+                    cellRule = pickle.load(fileObj, encoding='latin1')
         elif ext == 'json':
             with open(fileName, 'r') as fileObj:
                 cellRule = json.load(fileObj)


### PR DESCRIPTION
Load/dump a pickle file is not working in python 3. This PR makes the code compatible with python 2 and 3. Unfortunately, there is not a single command that works for both versions so I added an if/else clause.

Travis tests are working for this branch -> https://travis-ci.org/Neurosim-lab/netpyne/builds/427862225

References:
http://johnbachman.net/building-a-python-23-compatible-unicode-sandwich.html
https://stackoverflow.com/questions/28218466/unpickling-a-python-2-object-with-python-3
https://stackoverflow.com/questions/11305790/pickle-incompatibility-of-numpy-arrays-between-python-2-and-3/11314602