### PR TITLE
remove non-valid py3 methods

### DIFF
--- a/netpyne/specs/utils.py
+++ b/netpyne/specs/utils.py
@@ -11,7 +11,7 @@ from neuron import h
         
 def validateFunction(strFunc, netParamsVars):
     ''' returns True if "strFunc" can be evaluated'''
-    from math import exp, log, sqrt, int, sin, cos, tan, asin, acos, atan, sinh, cosh, tangh, pi, e 
+    from math import exp, log, sqrt, sin, cos, tan, asin, acos, atan, sinh, cosh, pi, e
     rand = h.Random()
     stringFuncRandMethods = ['binomial', 'discunif', 'erlang', 'geometric', 'hypergeo', 
         'lognormal', 'negexp', 'normal', 'poisson', 'uniform', 'weibull']

--- a/netpyne/specs/utils.py
+++ b/netpyne/specs/utils.py
@@ -11,7 +11,7 @@ from neuron import h
         
 def validateFunction(strFunc, netParamsVars):
     ''' returns True if "strFunc" can be evaluated'''
-    from math import exp, log, sqrt, sin, cos, tan, asin, acos, atan, sinh, cosh, pi, e
+    from math import exp, log, sqrt, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, pi, e
     rand = h.Random()
     stringFuncRandMethods = ['binomial', 'discunif', 'erlang', 'geometric', 'hypergeo', 
         'lognormal', 'negexp', 'normal', 'poisson', 'uniform', 'weibull']


### PR DESCRIPTION
@rodriguez-facundo  We missed this bit when we migrate to py3. Can you please have a look at it and change whatever is wrong?