### PR TITLE
returning gid as identity of a cell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 
 - Fixed bug in plotShape when cells sections not available
 
+- Return meaningful cell info via 'repr' and 'str' for pointCell, compartCell
+
+- Fixed spelling typos in documentation
+
 # Version 0.9.2
 
 - Support for saving simulation at intervals  

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -399,7 +399,7 @@ where:
 |                                        | fitness than the offspring           |
 +----------------------------------------+--------------------------------------+
 | ec.terminators.evaluation\_termination | terminator runs based on the number  |
-|                                        | of evaluations that have occured     |
+|                                        | of evaluations that have occurred    |
 +----------------------------------------+--------------------------------------+
 | ec.observers.stats\_observer           | indicates how many of the generated  |
 |                                        | individuals (parameter sets) will be |
@@ -506,7 +506,7 @@ value sets for the very first iteration, and evaluator being the fitness
 function that will be used to evaluate each model for how close it is to
 the target. In this example, the generator is a fairly straightforward
 function which creates an initial set of parameter values (i.e.
-[probability, weight, delay] ) by drawing from a parametrized uniform
+[probability, weight, delay] ) by drawing from a parameterized uniform
 distribution:
 
 .. code-block:: python

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -147,9 +147,9 @@ The ``addPopParams(label, params)`` method of the class ``netParams`` can be use
 
 It is also possible to create populations of artificial cells, i.e. point processes that generate spike events but don't have sections (e.g. NetStim, VecStim or IntFire2). In this case the ``cellModel`` field will specify the name of the point process mechanism, and the properties of the mechanism will be specified as additional fields. Note, since artificial cells are simpler they don't require to define separate cell parameters in the ``netParams.cellParams`` structure. For example, below are the fields required to create a population of NetStims (NEURON's artificial spike generator):
 
-* **pop** - An arbitrary label for this population assigned to all cells; can be used to as condition to apply specific connectivtiy rules. (e.g. 'background')
+* **pop** - An arbitrary label for this population assigned to all cells; can be used to as condition to apply specific connectivity rules. (e.g. 'background')
 
-* **cellModel** - Name of the point process artificical cell (e.g ``IntFire2``, ``NetStim`` o ``VecStim``).
+* **cellModel** - Name of the point process artificical cell (e.g ``IntFire2``, ``NetStim`` or ``VecStim``).
 
 * **numCells** - Number of cells
 
@@ -290,7 +290,7 @@ Example of two cell property rules added using different valid approaches::
 Synaptic mechanisms parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To define the parameteres of a synaptic mechanism, add items to the ``synMechParams`` ordered dict. You can use the addSynMechParams(label,params) method. Each ``synMechParams`` item consists of a key and value. The key is a an arbitrary label for this mechanism, which will be used to reference in the connectivity rules. The value is a dictionary of the synaptic mechanism parameters with the following fields:
+To define the parameters of a synaptic mechanism, add items to the ``synMechParams`` ordered dict. You can use the addSynMechParams(label,params) method. Each ``synMechParams`` item consists of a key and value. The key is a an arbitrary label for this mechanism, which will be used to reference in the connectivity rules. The value is a dictionary of the synaptic mechanism parameters with the following fields:
 
 * ``mod`` - the NMODL mechanism name (e.g. 'ExpSyn'); note this does not always coincide with the name of the mod file.
 
@@ -445,7 +445,7 @@ Each item of the ``connParams`` ordered dictionary consists of a key and value. 
 	e.g. ``'shape': {'switchOnOff': [200, 800], 'pulseType': 'square', 'pulsePeriod': 100, 'pulseWidth': 50}``
 
 * **plasticity** (optional) - Plasticity mechanism to use for this connections.
-	Requires 2 fields: ``mech`` to specifiy the name of the plasticity mechanism, and ``params`` containing a dictionary with the parameters of the mechanism 
+	Requires 2 fields: ``mech`` to specify the name of the plasticity mechanism, and ``params`` containing a dictionary with the parameters of the mechanism 
 
 	e.g. ``{'mech': 'STDP', 'params': {'hebbwt': 0.01, 'antiwt':-0.01, 'wmax': 50, 'RLon': 1 'tauhebb': 10}}``
 
@@ -465,7 +465,7 @@ Example of connectivity rules:
 
 	netParams.connParams['bg->all'] = {
 		'preConds': {'pop': 'background'}, 
-		'postConds': {'cellType': ['S','M'], 'ynorm': [0.1,0.6]}, # background -> S,M with ynrom in range 0.1 to 0.6
+		'postConds': {'cellType': ['S','M'], 'ynorm': [0.1,0.6]}, # background -> S,M with ynorm in range 0.1 to 0.6
 		'synReceptor': 'AMPA',					# target synaptic mechanism 
 		'weight': 0.01, 					# synaptic weight 
 		'delay': 5}						# transmission delay (ms) 
@@ -599,7 +599,7 @@ Each item of the ``stimSourceParams`` ordered dictionary consists of a key and a
 
 	* **stim params** (optional) - These will depend on the type of stimulator (e.g. for 'IClamp' will have 'del', 'dur' and 'amp')
 
-		Can be defined as a function (see :ref:`function_string`). Note for stims it only makes sense to use parameters of the postsynatic cell (e.g. 'post_ynorm').
+		Can be defined as a function (see :ref:`function_string`). Note for stims it only makes sense to use parameters of the postsynaptic cell (e.g. 'post_ynorm').
 
 
 Each item of the ``stimTargetParams`` specifies how to map a source of stimulation to a subset of cells in the network. The key is an arbitrary label for this mapping, and the value is a dictionary with the following parameters:
@@ -846,11 +846,11 @@ Analysis-related functions
     - *maxSpikes*: maximum number of spikes that will be plotted (int)
     - *orderBy*: Unique numeric cell property to order y-axis by, e.g. 'gid', 'ynorm', 'y' ('gid'|'y'|'ynorm'|...)
     - *orderInverse*: Invert the y-axis order (True|False)
-	- *labels*: Show population labels in a legend or overlayed on one side of raster ('legend'|'overlay'))
+	- *labels*: Show population labels in a legend or overlaid on one side of raster ('legend'|'overlay'))
     - *popRates*: Include population rates ('legend'|'overlay')
     - *spikeHist*: overlay line over raster showing spike histogram (spikes/bin) (None|'overlay'|'subplot')
     - *spikeHistBin*: Size of bin in ms to use for histogram  (int)
-    - *syncLines*: calculate synchorny measure and plot vertical lines for each spike to evidence synchrony (True|False)
+    - *syncLines*: calculate synchrony measure and plot vertical lines for each spike to evidence synchrony (True|False)
     - *figSize*: Size of figure ((width, height))
     - *saveData*: File name where to save the final data used to generate the figure (None|'fileName')
     - *saveFig*: File name where to save the figure (None|'fileName')
@@ -944,7 +944,7 @@ Analysis-related functions
     - *smooth*:  Window size for smoothing LFP; no smoothing if 0 (int)
     - *separation*: Separation factor between time-resolved LFP plots; multiplied by max LFP value (float)
     - *includeAxon*:  Whether to show the axon in the location plot (boolean)
-    - *figSize*: Size of figure ((width, heiight))
+    - *figSize*: Size of figure ((width, height))
     - *saveData*: File name where to save the final data used to generate the figure; if set to True uses filename from simConfig (None|True|'fileName')
     - *saveFig*: File name where to save the figure; if set to True uses filename from simConfig (None|True|'fileName')
     - *showFig*: Whether to show the figure or not (True|False)
@@ -1284,7 +1284,7 @@ Network class
 - cells (list of Cell objects)
 - params (NetParams object)
 
-After gatherting from nodes:
+After gathering from nodes:
 - allCells (list of Dicts)
 - allPops (list of Dicts)
 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -7,7 +7,7 @@ This tutorial provides an overview of how to use the NetPyNE python package to c
 
 Downloading and installation instructions here: :ref:`install`
 
-A good understading of python nested dictionaries and lists is recommended, since they are are used to specify the parameters. There are many good online Python courses available, e.g. http://www.codecademy.com/en/tracks/python or https://developers.google.com/edu/python/.
+A good understanding of python nested dictionaries and lists is recommended, since they are are used to specify the parameters. There are many good online Python courses available, e.g. http://www.codecademy.com/en/tracks/python or https://developers.google.com/edu/python/.
 
 .. seealso:: For a comprehensive description of all the features available in NetPyNE see :ref:`package_reference`.
 
@@ -42,7 +42,7 @@ To run the model just execute the `tut1.py` script. One way to do this is to run
 
 	nrniv -python tut1.py
 
-If you successfully installed MPI (e.g. OpenMPI) and NEURON with MPI support, you can simulate the model in parallel using multiple cores/processsors by typing:: 
+If you successfully installed MPI (e.g. OpenMPI) and NEURON with MPI support, you can simulate the model in parallel using multiple cores/processors by typing:: 
 
 	mpiexec -n 4 nrniv -python -mpi tut1.py
 
@@ -77,7 +77,7 @@ We begin with an overview of the Python objects where you will define all your n
 Network parameters (Tutorial 2)
 -------------------------------
 
-The ``netParams`` object includes all the information necessary to define your network. It is compoased of the following 8 ordered dictionaries:
+The ``netParams`` object includes all the information necessary to define your network. It is composed of the following 8 ordered dictionaries:
 
 * ``popParams`` - populations in the network and their parameters
 
@@ -246,7 +246,7 @@ We will add a rule to randomly connect the sensory to the motor population with 
 Simulation configuration options
 ---------------------------------
 
-Above we defined all the parameters related to the network model. Here we will specifiy the parameters or configuration of the simulation itself (e.g. duration), which is independent of the network.
+Above we defined all the parameters related to the network model. Here we will specify the parameters or configuration of the simulation itself (e.g. duration), which is independent of the network.
 
 The ``simConfig`` object can be used to customize options related to the simulation duration, timestep, recording of cell variables, saving data to disk, graph plotting, and others. All options have defaults values so it is not mandatory to specify any of them.
 
@@ -346,7 +346,7 @@ Using a simplified cell model (Izhikevich) (Tutorial 4)
 
 When dealing with large simulations it is sometimes useful to use simpler cell models for some populations, in order to gain speed. Here we will replace the HH model with the simpler Izhikevich cell model only for cells in the sensory (``S``) population. 
 
-The first step is to download the Izhikevich cell NEURON NMODL file which containes the Izhi2007b point process mechanism: :download:`izhi2007b.mod <code/mod/izhi2007b.mod>`
+The first step is to download the Izhikevich cell NEURON NMODL file which contains the Izhi2007b point process mechanism: :download:`izhi2007b.mod <code/mod/izhi2007b.mod>`
 
 Next we need to compile this .mod file so its ready to use by NEURON::
 
@@ -381,7 +381,7 @@ The full tutorial code for this example is available here: :download:`tut4.py <c
 Position and distance based connectivity (Tutorial 5)
 ---------------------------------------------------------
 
-The following example demonstrates how to spatially separate populations, add inhbitory populations, and implement weights, probabilities of connection and delays that depend on cell positions or distances.
+The following example demonstrates how to spatially separate populations, add inhibitory populations, and implement weights, probabilities of connection and delays that depend on cell positions or distances.
 
 We will build a cortical-like network with 6 populations (3 excitatory and 3 inhibitory) distributed in 3 layers: 2/3, 4 and 5. Create a new empty file called ``tut5.py`` and let's add the required code.   
 
@@ -504,7 +504,7 @@ Running the model now shows excitatory connections in red, and how cells in the 
 
 Finally, we add inhibitory connections which will project only onto excitatory cells, specified here using the ``pop`` attribute, for illustrative purposes (an equivalent rule would be: ``'postConds': {'cellType': 'E'}``). 
 
-To make the probability of connection decay exponentiall as a function of distance with a given length constant (``probLengthConst``), we can use the following distance-based expression: ``'probability': '0.4*exp(-dist_3D/probLengthConst)'``. The code for the inhibitory connectivity rule is therefore::
+To make the probability of connection decay exponential as a function of distance with a given length constant (``probLengthConst``), we can use the following distance-based expression: ``'probability': '0.4*exp(-dist_3D/probLengthConst)'``. The code for the inhibitory connectivity rule is therefore::
 
 	netParams.connParams['I->E'] = {
 	 'preConds': {'cellType': 'I'}, 'postConds': {'pop': ['E2','E4','E5']},       #  I -> E
@@ -829,7 +829,7 @@ The ``tut8_batch.py`` should look like this::
 		params['synMechTau2'] = [3.0, 5.0, 7.0]   
 		params['connWeight'] = [0.005, 0.01, 0.15]
 
-		# create Batch object with paramaters to modify, and specifying files to use
+		# create Batch object with parameters to modify, and specifying files to use
 		b = Batch(params=params, cfgFile='tut8_cfg.py', netParamsFile='tut8_netParams.py',)
 		
 		# Set output folder, grid method (all param combinations), and run configuration
@@ -897,11 +897,11 @@ Recording and plotting LFPs (Tutorial 9)
 
 Examples of how to record and analyze local field potentials (LFP) in single cells and networks are included in the \examples folder: `LFPrecording example <https://github.com/Neurosim-lab/netpyne/tree/development/examples/LFPrecording>`_ . LFP recording also works with parallel simulations.
 
-To record LFP just set the list of 3D locations of the LFP electrodes in the `simConfig` attribute `recordLFP` e.g. ``simConfig.recordLFP = e.g. [[50, 100, 50], [50, 200, 50]]`` (note the y coordinate represents depth, so will be represented as a negative value whehn plotted). The LFP signal in each electrode is obtained by summing the extracellular potential contributed by each segment of each neuron. Extracellular potentials are calculated using the "line source approximation" and assuming an Ohmic medium with conductivity sigma = 0.3 mS/mm. For more information on modeling LFPs see http://www.scholarpedia.org/article/Local_field_potential or https://doi.org/10.3389/fncom.2016.00065 .
+To record LFP just set the list of 3D locations of the LFP electrodes in the `simConfig` attribute `recordLFP` e.g. ``simConfig.recordLFP = e.g. [[50, 100, 50], [50, 200, 50]]`` (note the y coordinate represents depth, so will be represented as a negative value when plotted). The LFP signal in each electrode is obtained by summing the extracellular potential contributed by each segment of each neuron. Extracellular potentials are calculated using the "line source approximation" and assuming an Ohmic medium with conductivity sigma = 0.3 mS/mm. For more information on modeling LFPs see http://www.scholarpedia.org/article/Local_field_potential or https://doi.org/10.3389/fncom.2016.00065 .
 
 The recorded LFP signal will be stored in ``sim.allSimData['LFP']`` as a 2D list of size timeSteps * numElectrodes e.g. `sim.allSimData['LFP'][10][2]`` corresponds to the LFP value of electrode 2 at time step 10. It is possible to record the LFP signal generated by each individual cell by setting ``simConfig.saveLFPCells = True`` -- this will be stored in ``sim.allSimData['LFPCells']`` as a 3D list with size cells * timeSteps * numElectrodes. 
 
-To plot the LFP use the ``sim.analysis.plotLFP()`` method. This allows to plot for each electrode: 1) the time-resolved LFP signal ('timeSeries'), 2) the power spectral density ('PSD'), 3) the spectrogram / time-frequency profile ('spectrogram'), 4) and the 3D locations of the electrodes overlayed over the model neurons ('locations'). See :ref:`analysis_functions` for the full list of ``plotLFP()`` arguments.
+To plot the LFP use the ``sim.analysis.plotLFP()`` method. This allows to plot for each electrode: 1) the time-resolved LFP signal ('timeSeries'), 2) the power spectral density ('PSD'), 3) the spectrogram / time-frequency profile ('spectrogram'), 4) and the 3D locations of the electrodes overlaid over the model neurons ('locations'). See :ref:`analysis_functions` for the full list of ``plotLFP()`` arguments.
 
 The first example ( :download:`cell_lfp.py <../../examples/LFPrecording/cell_lfp.py>`) shows LFP recording for a single cell -- M1 corticospinal neuron --  with 700+ compartments (segments) and multiple somatic and dendritic ionic channels. The cell parameters are loaded from a .json file. The cell receives NetStim input to its soma via an excitatory synapse. Ten LFP electrodes are placed at both sides of the neuron at 5 different cortical depths. The soma voltage, LFP time-resolved signal and the 3D locations of the electrodes are plotted:
 

--- a/netpyne/cell/compartCell.py
+++ b/netpyne/cell/compartCell.py
@@ -56,10 +56,9 @@ class CompartCell (Cell):
 
     def __str__ (self):
         try:
-            gid = self.gid # only use if gid exists
-            return 'gid=%d'%(self.gid)
-        except:
-            return 'no gid'
+            gid, cpo, cmo = self.gid, self.tags['pop'], self.tags['cellModel'] # only use if these exist
+            return 'compartCell_%s_%s_%d'%(cty, cpo, gid)
+        except: return 'compartCell%d'%gid
 
     def __repr__ (self):
         return self.__str__()

--- a/netpyne/cell/compartCell.py
+++ b/netpyne/cell/compartCell.py
@@ -57,7 +57,7 @@ class CompartCell (Cell):
     def __str__ (self):
         try:
             gid, cty, cmo = self.gid, self.tags['cellType'], self.tags['cellModel'] # only use if these exist
-            return 'compartCell_%s_%s_%d'%(cty, cty, gid)
+            return 'compartCell_%s_%s_%d'%(cty, cmo, gid)
         except: return 'compartCell%d'%self.gid
 
     def __repr__ (self):

--- a/netpyne/cell/compartCell.py
+++ b/netpyne/cell/compartCell.py
@@ -54,6 +54,16 @@ class CompartCell (Cell):
         if create: self.create()  # create cell 
         if associateGid: self.associateGid() # register cell for this node
 
+    def __str__ (self):
+        try:
+            gid = self.gid # only use if gid exists
+            return 'gid=%d'%(self.gid)
+        except:
+            return 'no gid'
+
+    def __repr__ (self):
+        return self.__str__()
+
     def create (self):
         from .. import sim
 

--- a/netpyne/cell/compartCell.py
+++ b/netpyne/cell/compartCell.py
@@ -56,9 +56,9 @@ class CompartCell (Cell):
 
     def __str__ (self):
         try:
-            gid, cpo, cmo = self.gid, self.tags['pop'], self.tags['cellModel'] # only use if these exist
-            return 'compartCell_%s_%s_%d'%(cty, cpo, gid)
-        except: return 'compartCell%d'%gid
+            gid, cty, cmo = self.gid, self.tags['cellType'], self.tags['cellModel'] # only use if these exist
+            return 'compartCell_%s_%s_%d'%(cty, cty, gid)
+        except: return 'compartCell%d'%self.gid
 
     def __repr__ (self):
         return self.__str__()

--- a/netpyne/cell/pointCell.py
+++ b/netpyne/cell/pointCell.py
@@ -48,8 +48,8 @@ class PointCell (Cell):
 
     def __str__ (self):
         try:
-            gid, cpo, cmo = self.gid, self.tags['pop'], self.tags['cellModel'] # only use if these exist
-            return 'pointCell_%s_%s_%d'%(cty, cpo, gid)
+            gid, cmo = self.gid, self.tags['cellModel'] # only use if these exist
+            return 'pointCell_%s_%d'%(cmo, gid)
         except: return 'pointCell%d'%self.gid
 
     def __repr__ (self):

--- a/netpyne/cell/pointCell.py
+++ b/netpyne/cell/pointCell.py
@@ -46,6 +46,14 @@ class PointCell (Cell):
             self.createNEURONObj()  # create cell 
         if associateGid: self.associateGid() # register cell for this node
 
+    def __str__ (self):
+        try:
+            gid, cpo, cmo = self.gid, self.tags['pop'], self.tags['cellModel'] # only use if these exist
+            return 'pointCell_%s_%s_%d'%(cty, cpo, gid)
+        except: return 'pointCell%d'%self.gid
+
+    def __repr__ (self):
+        return self.__str__()
 
     def createNEURONObj (self):
         from .. import sim


### PR DESCRIPTION
I'm not really sure that this is the best label to use (gid) but seems better than current default which is meaningless.  eg <netpyne.cell.compartCell.CompartCell at 0x7f4e06eaaa90>
now returning:
In [7]: sim.net.cells[0].secs.soma.hObj.hname()
Out[7]: 'gid=0.soma'
In [8]: sim.net.cells[0].secs.soma.hObj.cell()
Out[8]: gid=0

Might be nice to have other info in the string as well e.g. cellType cellModel -- I didn't add them since wasn't sure if those are obligatory tags -- if they are then let me know and i'll put those in.  Problem with gid is that it seems that it's not obligatory for some reason?  If cellType cellModel available then I would also put these into the name=  

I also note that there is some debate online about the desirability of having __repr__ return __str__ but need that to get this string returned here
