### PR TITLE
Enhancements for simulating dipole experiments

### DIFF
--- a/netpyne/cell/compartCell.py
+++ b/netpyne/cell/compartCell.py
@@ -39,8 +39,7 @@ from ..specs import Dict
 #
 ###############################################################################
 
-# --- Temporarily copied from HNN code; improve so doesn't use h globals ---  
-# global variables for dipole calculation, should be node-independent 
+# --- Temporarily copied from HNN code ---
 
 class CompartCell (Cell):
     ''' Class for section-based neuron models '''
@@ -65,9 +64,6 @@ class CompartCell (Cell):
     def create (self):
         from .. import sim
                 
-        if sim.cfg.recordDipoles:
-            h("dp_total_L2 = 0."); h("dp_total_L5 = 0.") # put here since these variables used in cells
-
         # generate random rotation angle for each cell
         if sim.net.params.rotateCellsRandomly:
             if isinstance(sim.net.params.rotateCellsRandomly, list):
@@ -258,7 +254,7 @@ class CompartCell (Cell):
         return L
 
     # insert dipole in section
-    def __dipoleInsert(self, secName, sec):
+    def __dipoleInsert(self, secName, sec, cell_dpl_ref):
 
         # insert dipole mech (dipole.mod)
         try:
@@ -278,10 +274,7 @@ class CompartCell (Cell):
         dpp.ri = h.ri(1, sec=sec['hObj'])
         # sets pointers in dipole mod file to the correct locations -- h.setpointer(ref, ptr, obj)
         h.setpointer(sec['hObj'](0.99)._ref_v, 'pv', dpp)
-        if self.tags['cellType'].startswith('L2'):
-            h.setpointer(h._ref_dp_total_L2, 'Qtotal', dpp)
-        elif self.tags['cellType'].startswith('L5'):
-            h.setpointer(h._ref_dp_total_L5, 'Qtotal', dpp)
+        h.setpointer(cell_dpl_ref, 'Qtotal', dpp)
 
         # gives INTERNAL segments of the section, non-endpoints
         # creating this because need multiple values simultaneously
@@ -303,11 +296,7 @@ class CompartCell (Cell):
             else:
                 h.setpointer(sec['hObj'](0)._ref_v, 'pv', sec['hObj'](loc[i]).dipole)
             # set aggregate pointers
-            h.setpointer(dpp._ref_Qsum, 'Qsum', sec['hObj'](loc[i]).dipole)
-            if self.tags['cellType'].startswith('L2'):
-                h.setpointer(h._ref_dp_total_L2, 'Qtotal', sec['hObj'](loc[i]).dipole)
-            elif self.tags['cellType'].startswith('L5'):
-                h.setpointer(h._ref_dp_total_L5, 'Qtotal', sec['hObj'](loc[i]).dipole)
+            h.setpointer(cell_dpl_ref, 'Qtotal', sec['hObj'](loc[i]).dipole)
             # add ztan values
             sec['hObj'](loc[i]).dipole.ztan = y_diff[i]
         # set the pp dipole's ztan value to the last value from y_diff
@@ -433,10 +422,15 @@ class CompartCell (Cell):
 
         # add dipoles
         if sim.cfg.recordDipoles:
+            #  Vectors can't be stored in Cell class because it gets pickled
+            sim.net.cells_dpl[self.gid] = h.Vector(1)  # create a simple hoc object to store the dipole value for this cell
+            cells_dpl_ref = sim.net.cells_dpl[self.gid]._ref_x[0]
+            sim.net.cells_dpls[self.gid] = h.Vector().record(cells_dpl_ref)  # set up recording of current value
+
             for sectName,sectParams in prop['secs'].items():
                 sec = self.secs[sectName]
                 if 'mechs' in sectParams and 'dipole' in sectParams['mechs']:
-                    self.__dipoleInsert(sectName, sec)  # add dipole mechanisms to each section
+                    self.__dipoleInsert(sectName, sec, cells_dpl_ref)  # add dipole mechanisms to each section
 
         # Print message about error inserting mechanisms
         if mechInsertError:

--- a/netpyne/network/network.py
+++ b/netpyne/network/network.py
@@ -39,6 +39,8 @@ class Network (object):
 
         self.pops = ODict()  # list to store populations ('Pop' objects)
         self.cells = [] # list to store cells ('Cell' objects)
+        self.cells_dpls = {} # dict with vectors of dipole over time for each cell
+        self.cells_dpl = {} # dict with vectors of dipole at one time for each cell
 
         self.gid2lid = {} # Empty dict for storing GID -> local index (key = gid; value = local id) -- ~x6 faster than .index() 
         self.lastGid = 0  # keep track of last cell gid 

--- a/netpyne/sim/gather.py
+++ b/netpyne/sim/gather.py
@@ -58,7 +58,10 @@ def gatherData (gatherLFP = True):
             except:
                 pass
     simDataVecs = ['spkt', 'spkid', 'stims'] + list(sim.cfg.recordTraces.keys())
-    if sim.cfg.recordDipoles: simDataVecs.append('dipole')
+    if sim.cfg.recordDipoles:
+        _aggregateDipoles()
+        simDataVecs.append('dipole')
+
     singleNodeVecs = ['t']
     if sim.nhosts > 1:  # only gather if >1 nodes
         netPopsCellGids = {popLabel: list(pop.cellGids) for popLabel,pop in sim.net.pops.items()}
@@ -79,6 +82,9 @@ def gatherData (gatherLFP = True):
                 for k in list(gather[0]['simData'].keys()):  # initialize all keys of allSimData dict
                     if gatherLFP and k == 'LFP':
                         sim.allSimData[k] = np.zeros((gather[0]['simData']['LFP'].shape))
+                    elif sim.cfg.recordDipoles and k == 'dipole':
+                        sim.allSimData[k]['L2'] = np.zeros(len(gather[0]['simData']['dipole']['L2']))
+                        sim.allSimData[k]['L5'] = np.zeros(len(gather[0]['simData']['dipole']['L5']))
                     else:
                         sim.allSimData[k] = {}
 
@@ -90,13 +96,15 @@ def gatherData (gatherLFP = True):
                     for key,val in node['simData'].items():  # update simData dics of dics of h.Vector
                         if key in simDataVecs:          # simData dicts that contain Vectors
                             if isinstance(val, dict):
-                                for cell,val2 in val.items():
+                                for key2,val2 in val.items():
                                     if isinstance(val2,dict):
-                                        sim.allSimData[key].update(Dict({cell:Dict()}))
+                                        sim.allSimData[key].update(Dict({key2:Dict()}))
                                         for stim,val3 in val2.items():
-                                            sim.allSimData[key][cell].update({stim:list(val3)}) # udpate simData dicts which are dicts of dicts of Vectors (eg. ['stim']['cell_1']['backgrounsd']=h.Vector)
+                                            sim.allSimData[key][key2].update({stim:list(val3)}) # udpate simData dicts which are dicts of dicts of Vectors (eg. ['stim']['cell_1']['backgrounsd']=h.Vector)
+                                    elif key == 'dipole':
+                                        sim.allSimData[key][key2] = np.add(sim.allSimData[key][key2],val2.as_numpy()) # add together dipole values from each node
                                     else:
-                                        sim.allSimData[key].update({cell:list(val2)})  # udpate simData dicts which are dicts of Vectors (eg. ['v']['cell_1']=h.Vector)
+                                        sim.allSimData[key].update({key2:list(val2)})  # udpate simData dicts which are dicts of Vectors (eg. ['v']['cell_1']=h.Vector)
                             else:
                                 sim.allSimData[key] = list(sim.allSimData[key])+list(val) # udpate simData dicts which are Vectors
                         elif gatherLFP and key == 'LFP':
@@ -135,6 +143,9 @@ def gatherData (gatherLFP = True):
                 for k in list(gather[0]['simData'].keys()):  # initialize all keys of allSimData dict
                     if gatherLFP and k == 'LFP':
                         sim.allSimData[k] = np.zeros((gather[0]['simData']['LFP'].shape))
+                    elif sim.cfg.recordDipoles and k == 'dipole':
+                        sim.allSimData[k]['L2'] = np.zeros(len(gather[0]['simData']['dipole']['L2']))
+                        sim.allSimData[k]['L5'] = np.zeros(len(gather[0]['simData']['dipole']['L5']))
                     else:
                         sim.allSimData[k] = {}
 
@@ -150,13 +161,15 @@ def gatherData (gatherLFP = True):
                     for key,val in node['simData'].items():  # update simData dics of dics of h.Vector
                         if key in simDataVecs:          # simData dicts that contain Vectors
                             if isinstance(val,dict):
-                                for cell,val2 in val.items():
+                                for key2,val2 in val.items():
                                     if isinstance(val2,dict):
-                                        sim.allSimData[key].update(Dict({cell:Dict()}))
+                                        sim.allSimData[key].update(Dict({key2:Dict()}))
                                         for stim,val3 in val2.items():
-                                            sim.allSimData[key][cell].update({stim:list(val3)}) # udpate simData dicts which are dicts of dicts of Vectors (eg. ['stim']['cell_1']['backgrounsd']=h.Vector)
+                                            sim.allSimData[key][key2].update({stim:list(val3)}) # udpate simData dicts which are dicts of dicts of Vectors (eg. ['stim']['cell_1']['backgrounsd']=h.Vector)
+                                    elif key == 'dipole':
+                                        sim.allSimData[key][key2] = np.add(sim.allSimData[key][key2],val2.as_numpy()) # add together dipole values from each node
                                     else:
-                                        sim.allSimData[key].update({cell:list(val2)})  # udpate simData dicts which are dicts of Vectors (eg. ['v']['cell_1']=h.Vector)
+                                        sim.allSimData[key].update({key2:list(val2)})  # udpate simData dicts which are dicts of Vectors (eg. ['v']['cell_1']=h.Vector)
                             else:
                                 sim.allSimData[key] = list(sim.allSimData[key])+list(val) # udpate simData dicts which are Vectors
                         elif gatherLFP and key == 'LFP':
@@ -530,3 +543,15 @@ def _gatherCells ():
         sim.net.allCells = [c.__getstate__() for c in sim.net.cells]
 
 
+#------------------------------------------------------------------------------
+# Aggregate dipole data for each cell on nodes
+#------------------------------------------------------------------------------
+def _aggregateDipoles ():
+    from .. import sim
+
+    dipole_cells = [c for c in sim.net.cells if type(c) is sim.CompartCell]
+    for cell in dipole_cells:
+        if cell.tags['cellType'] == 'L2Pyr':
+            sim.simData['dipole']['L2'].add(sim.net.cells_dpls[cell.gid])
+        if cell.tags['cellType'] == 'L5Pyr':
+            sim.simData['dipole']['L5'].add(sim.net.cells_dpls[cell.gid])

--- a/netpyne/sim/run.py
+++ b/netpyne/sim/run.py
@@ -100,7 +100,7 @@ def preRun ():
 #------------------------------------------------------------------------------
 # Run Simulation
 #------------------------------------------------------------------------------
-def runSim (reRun=False):
+def runSim (skipPreRun=False):
     from .. import sim
 
     sim.pc.barrier()
@@ -113,7 +113,7 @@ def runSim (reRun=False):
     sim.pc.barrier()
     sim.timing('start', 'runTime')
 
-    if not reRun:
+    if not skipPreRun:
         preRun()
     
     h.finitialize(float(sim.cfg.hParams['v_init']))

--- a/netpyne/sim/run.py
+++ b/netpyne/sim/run.py
@@ -100,7 +100,7 @@ def preRun ():
 #------------------------------------------------------------------------------
 # Run Simulation
 #------------------------------------------------------------------------------
-def runSim ():
+def runSim (reRun=False):
     from .. import sim
 
     sim.pc.barrier()
@@ -111,8 +111,10 @@ def runSim ():
         except:
             if sim.cfg.verbose: 'Error Failed to use local dt.'
     sim.pc.barrier()
-    sim.timing('start', 'runTime') 
-    preRun()
+    sim.timing('start', 'runTime')
+
+    if not reRun:
+        preRun()
     
     h.finitialize(float(sim.cfg.hParams['v_init']))
 

--- a/netpyne/sim/setup.py
+++ b/netpyne/sim/setup.py
@@ -325,12 +325,10 @@ def setupRecording ():
         setupRecordLFP()
 
     # try to record dipoles
-    
     if sim.cfg.recordDipoles:
-        dp_rec_L2 = h.Vector()
-        dp_rec_L5 = h.Vector()
-        dp_rec_L2.record(h._ref_dp_total_L2) # L2 dipole recording
-        dp_rec_L5.record(h._ref_dp_total_L5)  # L5 dipole recording
+        recordStep = 0.1 if sim.cfg.recordStep == 'adaptive' else sim.cfg.recordStep
+        dp_rec_L2 = h.Vector(sim.cfg.duration/recordStep+1)
+        dp_rec_L5 = h.Vector(sim.cfg.duration/recordStep+1)
         sim.simData['dipole'] = {'L2': dp_rec_L2, 'L5': dp_rec_L5}  
     
     sim.timing('stop', 'setrecordTime')


### PR DESCRIPTION
There are two enhancements proposed by this PR:
1) a new option to runSim(reRun=True) that skips calling preRun() so that runSim() can be repeatedly called.
2) a scheme for gathering the dipole values from each cell in a way that does not require global variables. This scheme aggregates the dipole when run via MPI and enables CVode.cache_efficient(1) for a speedup.

These would enable HNN to run more efficient simulations via NetPyNE.