### PR TITLE
Add rxdmath to dynamicVars.

### DIFF
--- a/netpyne/network/netrxd.py
+++ b/netpyne/network/netrxd.py
@@ -493,7 +493,7 @@ def _addRates(self, params):
 
     for label, param in params.items():
 
-        dynamicVars = {'sim': sim , 'rxd' : rxd}
+        dynamicVars = {'sim': sim , 'rxdmath': rxdmath', 'rxd' : rxd}
 
         # species
         if 'species' not in param:

--- a/netpyne/network/netrxd.py
+++ b/netpyne/network/netrxd.py
@@ -386,7 +386,7 @@ def _addReactions(self, params, multicompartment=False):
 
     for label, param in params.items():
 
-        dynamicVars = {'sim': sim , 'rxd' : rxd}
+        dynamicVars = {'sim': sim, 'rxdmath': rxdmath, 'rxd': rxd}
 
         # reactant
         if 'reactant' not in param:


### PR DESCRIPTION
There is a problem parsing rates with `rxdmath` terms, e.g. `rxdmath.exp`, but rxd.rxdmath works. Suggest adding rxdmath to dynamicVars to fix this.