### PR TITLE
Continuous Integration renovation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,16 +18,10 @@ jobs:
     <<: *defaults
 
     parallelism: 1
-    #environment:
-    #  TRAVIS_BUILD_DIR: `pwd`
-    #  NEURON_HOME: ~/neuron
-    #  PATH: $PATH:$NEURON_HOME/x86_64/bin
-    #  PYTHONPATH: $PYTHONPATH:$TRAVIS_BUILD_DIR:$NEURON_HOME/lib/python/
-
     steps:
       - checkout
       # Use BASH instead of DASH! see: https://ubuntuforums.org/showthread.php?t=1932504
-      - run: git fetch --unshallow || true
+      #- run: git fetch --unshallow || true
       - run: apt-get update
       - run: apt-get install -y sudo # https://discuss.circleci.com/t/sudo-command-not-found/14208/4
       - run: ls -al /bin/sh && sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh && ls -al /bin/sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - checkout
       # Use BASH instead of DASH! see: https://ubuntuforums.org/showthread.php?t=1932504
-      #- run: git fetch --unshallow || true
+      - run: git fetch --unshallow || true
       - run: apt-get update
       - run: apt-get install -y sudo # https://discuss.circleci.com/t/sudo-command-not-found/14208/4
       - run: ls -al /bin/sh && sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh && ls -al /bin/sh
@@ -34,4 +34,4 @@ jobs:
       - run: apt-get install -y libxext-dev
       - run: apt-get install -y libncurses-dev
       - run: apt-get install -y make
-      - run: bash build.sh
+      - run: bash tox_ci_build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+# Netpyne circleci testing script
+defaults: &defaults
+  working_directory: ~/markovmodel/PyEMMA
+  docker:
+    - image: continuumio/miniconda3
+
+
+inst_conda_bld: &inst_conda_bld
+  - run: conda config --add channels conda-forge
+  - run: conda config --set always_yes true
+  - run: conda config --set quiet true
+  - run: conda install conda-build
+
+version: 2
+
+jobs:
+  build:
+    <<: *defaults
+
+    parallelism: 1
+    #environment:
+    #  TRAVIS_BUILD_DIR: `pwd`
+    #  NEURON_HOME: ~/neuron
+    #  PATH: $PATH:$NEURON_HOME/x86_64/bin
+    #  PYTHONPATH: $PYTHONPATH:$TRAVIS_BUILD_DIR:$NEURON_HOME/lib/python/
+
+    steps:
+      - checkout
+      # Use BASH instead of DASH! see: https://ubuntuforums.org/showthread.php?t=1932504
+      - run: git fetch --unshallow || true
+      - run: apt-get update
+      - run: apt-get install -y sudo # https://discuss.circleci.com/t/sudo-command-not-found/14208/4
+      - run: ls -al /bin/sh && sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh && ls -al /bin/sh
+
+      - run: apt-get install -y python-tk python-sympy python-tables locales
+      - run: apt-get install -y wget gcc g++ build-essential libncurses-dev
+      - run: apt-get install -y libpython-dev cython libx11-dev git flex
+      - run: apt-get install -y automake
+      - run: apt-get install -y libtool
+      - run: apt-get install -y libxext-dev
+      - run: apt-get install -y libncurses-dev
+      - run: apt-get install -y make
+      - run: bash build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: Build
-name: Build
 
 on:
-  schedule:
-    # Runs every sunday at 3 a.m.
-    - cron: '0 3 * * SUN'
   push:
     branches:
       - development

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This package is developed and maintained by the Neurosim lab (www.neurosimlab.or
 
 [![Build Status](https://travis-ci.org/Neurosim-lab/netpyne.svg?branch=development)](https://travis-ci.org/Neurosim-lab/netpyne)
 
+[![Build Status](https://circleci.com/gh/russelljjarvis/netpyne/tree/development.svg?style=svg)](https://app.circleci.com/pipelines/github/russelljjarvis/netpyne/)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+[tox]
+envlist = py{3}-{unit}
+
+[gh-actions]
+python =
+    3.6: py3
+    3.7: py3
+    3.8: py3
+    3.9: py3
+
+[testenv]
+envdir =
+    py3{5,6,7,8,}{-unit,-syntax}: {toxworkdir}/py3
+    docs: {toxworkdir}/docs
+deps =
+    coverage
+    flake8
+    mock
+    nose
+    sh
+    pathlib
+    bash
+download = true
+whitelist_externals =
+    make
+    find
+    cd
+    pwd
+    export
+    echo
+    git
+    apt-get
+    pip
+    conda
+    sudo
+passenv = https_proxy
+commands =
+    bash tox_ci_build.sh
+    syntax: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/tox_ci_build.sh
+++ b/tox_ci_build.sh
@@ -1,0 +1,63 @@
+PYTHON="$(which python)"
+PIP="$(which pip)"
+echo $PYTHON
+sudo $PIP install -e .
+sudo $PIP install neuron
+$PYTHON -c "import neuron"
+$PYTHON -c "from neuron import h"
+
+apt-get update
+apt-get install -y python-tk python-sympy python-tables locales
+apt-get install -y wget gcc g++ build-essential libncurses-dev
+apt-get install -y libpython-dev cython libx11-dev git flex
+apt-get install -y automake libtool libxext-dev libncurses-dev make bison
+pip install numpy matplotlib scipy pandas future tables bokeh
+pip install pyneuroml # This will install libNeuroML also
+git clone https://github.com/neuronsimulator/nrn
+cd nrn
+export NEURON_HOME=$(pwd)
+sudo ./configure --without-x --with-nrnpython=$PYTHON --without-paranrn --without-iv --prefix=$pwd
+sudo make
+sudo make install
+cd src/nrnpython
+sudo $PYTHON setup.py install
+cd -
+cd ../examples
+$PYTHON -c "import neuron"
+$PYTHON -c "from neuron import h"
+cd HHTut
+$NEURON_HOME/x86_64/bin/nrnivmodl .
+$PYTHON HHTut_run.py -nogui
+$PYTHON HHTut_export.py -nogui
+# HybridTut example
+cd ../HybridTut
+$NEURON_HOME/x86_64/bin/nrnivmodl .
+$PYTHON HybridTut_run.py -nogui
+$PYTHON HybridTut_export.py -nogui
+# M1 example
+cd ../M1
+$NEURON_HOME/x86_64/bin/nrnivmodl .
+$PYTHON M1_run.py -nogui
+$PYTHON M1_export.py -nogui
+# PTcell example
+cd ../PTcell
+$NEURON_HOME/x86_64/bin/nrnivmodl .
+$PYTHON init.py -nogui
+# LFP recording
+cd ../LFPrecording
+$NEURON_HOME/x86_64/bin/nrnivmodl .
+$PYTHON cell_lfp.py -nogui
+# LFP recording
+cd ../saving
+$PYTHON init.py -nogui
+# RxD buffering
+cd ../rxd_buffering
+$PYTHON buffering.py -nogui
+# RxD net
+cd ../rxd_net
+$NEURON_HOME/x86_64/bin/nrnivmodl .
+$PYTHON init.py -nogui
+# NeuroML import example
+#cd ../NeuroMLImport/
+#$NEURON_HOME/x86_64/bin/nrnivmodl .
+#$PYTHON SimpleNet_import.py -nogui

--- a/workflows/main.yml
+++ b/workflows/main.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  schedule:
+    # Runs every sunday at 3 a.m.
+    - cron: '0 3 * * SUN'
+  push:
+    branches:
+      - development
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools
+        pip install tox 
+    - name: Run tox
+      run: tox
+  


### PR DESCRIPTION
Hi there,

I was compelled to create a PR due to this [internship application](http://dura-bernal.org/internships)

As discussed in other related community driven neuroscience [modelling projects](https://github.com/NeuralEnsemble/libNeuroML/issues/97), due to policy changes free travis continous integration is about to become unworkable for many people.

In this PR I have implemented two CI alternative worklows to choose from. The first is .circleci (see the second build success badge in the README.md below the travis one). The second is tox via Github Actions. I chose to adopt .tox/Github actions, as that was the choice of [BluePyOpt](https://github.com/BlueBrain/BluePyOpt/blob/master/.github/workflows/main.yml). Circle-CI has its own portal, and overall it is a very similar feel to travis. 



 


