### PR TITLE
Untested fix for the issue 506

### DIFF
--- a/netpyne/analysis/interactive.py
+++ b/netpyne/analysis/interactive.py
@@ -1847,7 +1847,7 @@ def iplotLFP(electrodes=['avg', 'all'], plots=['timeSeries', 'PSD', 'spectrogram
                 color = colors[i%len(colors)]
 
             legend=str(elec)
-            figs['timeSeries'].line(t, lfpPlot+(i*ydisp), color=color, name=str(elec), legend=legend)
+            figs['timeSeries'].line(t, lfpPlot+(i*ydisp), color=color, name=str(elec), legend_label=legend)
 
         data['lfpPlot'] = lfpPlot
         data['ydisp'] =  ydisp


### PR DESCRIPTION
The error reported in issue #506 was due to an upgrade in bokeh library, which removed [backward compatibility](https://github.com/PatrikHlobil/Pandas-Bokeh/issues/51). 
However, It was not possible to test it, as no module for checking interactive plotting was found.