### PR TITLE
Fail with better error message on import failure for sonatalImport

### DIFF
--- a/netpyne/conversion/sonataImport.py
+++ b/netpyne/conversion/sonataImport.py
@@ -26,7 +26,7 @@ except ModuleNotFoundError as error:
             except ModuleNotFoundError as error:
                 needed.append(error.name)
         print('Note: SONATA import failed; import/export functions for SONATA will not be available.\n' +
-              '  To use this feature install those Python packages: ', needed)
+              '  To use this feature install these Python packages: ', needed)
 except ImportError as error:
     from neuron import h
     pc = h.ParallelContext() # MPI: Initialize the ParallelContext class

--- a/netpyne/conversion/sonataImport.py
+++ b/netpyne/conversion/sonataImport.py
@@ -13,15 +13,20 @@ try:
     from pyneuroml import pynml
     from . import neuromlFormat  # import NetPyNEBuilder
     from  netpyne.support.nml_reader  import NMLTree
-except ModuleNotFoundError as error:
-    print(error)
-    print('Note: You have to install `{}`'.format(error.name))
-    exit()
-except ImportError:
+except ImportError as error:
+    # soft-fail and suggest which packages to install
     from neuron import h
     pc = h.ParallelContext() # MPI: Initialize the ParallelContext class
     if int(pc.id()) == 0:  # only print for master node
-        print('Note: SONATA import failed; import/export functions for SONATA will not be available. \n  To use this feature please install "HDF5" and the "tables" Python package.')
+        needed = [error.name]
+        for pkg in ['tables', 'pyneuroml', 'neuroml']:
+            try:
+                if pkg not in needed:
+                    __import__(pkg)
+            except ImportError as error:
+                needed.append(error.name)
+        print('Note: SONATA import failed; import/export functions for SONATA will not be available.\n' +
+              '      To use this feature install those Python packages: ', needed)
 
 from . import neuronPyHoc
 from .. import sim, specs

--- a/netpyne/conversion/sonataImport.py
+++ b/netpyne/conversion/sonataImport.py
@@ -13,7 +13,7 @@ try:
     from pyneuroml import pynml
     from . import neuromlFormat  # import NetPyNEBuilder
     from  netpyne.support.nml_reader  import NMLTree
-except ImportError as error:
+except ModuleNotFoundError as error:
     # soft-fail and suggest which packages to install
     from neuron import h
     pc = h.ParallelContext() # MPI: Initialize the ParallelContext class
@@ -23,10 +23,16 @@ except ImportError as error:
             try:
                 if pkg not in needed:
                     __import__(pkg)
-            except ImportError as error:
+            except ModuleNotFoundError as error:
                 needed.append(error.name)
         print('Note: SONATA import failed; import/export functions for SONATA will not be available.\n' +
               '  To use this feature install those Python packages: ', needed)
+except ImportError as error:
+    from neuron import h
+    pc = h.ParallelContext() # MPI: Initialize the ParallelContext class
+    if int(pc.id()) == 0:  # only print for master node
+        print('Note: SONATA import failed; import/export functions for SONATA will not be available.\n', error)
+
 
 from . import neuronPyHoc
 from .. import sim, specs

--- a/netpyne/conversion/sonataImport.py
+++ b/netpyne/conversion/sonataImport.py
@@ -13,6 +13,10 @@ try:
     from pyneuroml import pynml
     from . import neuromlFormat  # import NetPyNEBuilder
     from  netpyne.support.nml_reader  import NMLTree
+except ModuleNotFoundError as error:
+    print(error)
+    print('Note: You have to install `{}`'.format(error.name))
+    exit()
 except ImportError:
     from neuron import h
     pc = h.ParallelContext() # MPI: Initialize the ParallelContext class

--- a/netpyne/conversion/sonataImport.py
+++ b/netpyne/conversion/sonataImport.py
@@ -26,7 +26,7 @@ except ImportError as error:
             except ImportError as error:
                 needed.append(error.name)
         print('Note: SONATA import failed; import/export functions for SONATA will not be available.\n' +
-              '      To use this feature install those Python packages: ', needed)
+              '  To use this feature install those Python packages: ', needed)
 
 from . import neuronPyHoc
 from .. import sim, specs


### PR DESCRIPTION
Before:
```
>>> from netpyne.conversion import sonataImport
Note: SONATA import failed; import/export functions for SONATA will not be available. 
  To use this feature please install "HDF5" and the "tables" Python package.
```

After:
```
>>> from netpyne.conversion import sonataImport
Note: SONATA import failed; import/export functions for SONATA will not be available.
  To use this feature install those Python packages:  ['tables', 'pyneuroml', 'neuroml']
```

unclear for me whats the relationship of neuroml and hdf5 right now