### PR TITLE
Updated sim.clearAll for rxd

### DIFF
--- a/netpyne/sim/utils.py
+++ b/netpyne/sim/utils.py
@@ -928,6 +928,9 @@ def clearAll():
         rxd.species._has_3d = False
         rxd.rxd._zero_volume_indices = np.ndarray(0, dtype=np.int_)
         rxd.set_solve_type(dimension=1)
+        # clear reactions in case next sim does not use rxd
+        rxd.rxd.clear_rates()
+        
 
         #except:
         #    pass


### PR DESCRIPTION
I think we need to call rxd.clear_rates(), it would be cleared by the next rxd simulation (which is why we don't need it for CI) but is a problem if the next simulation doesn't use rxd.