### PR TITLE
Import Dict in spikes.py

### DIFF
--- a/netpyne/analysis/spikes.py
+++ b/netpyne/analysis/spikes.py
@@ -31,7 +31,7 @@ from .utils import exception #, getInclude, getSpktSpkid
 from .tools import getInclude, getSpktSpkid
 from .tools import saveData as saveFigData
 from ..support.scalebar import add_scalebar
-
+from ..specs import Dict
 
 @exception
 def prepareSpikeData(


### PR DESCRIPTION
When running the M1 simulation I got the following error with the current `development` branch:
```
Analyzing...
  Cells: 1078
  Connections: 0 (0.00 per cell)
  Spikes: 0 (0.00 Hz)
  Simulated time: 0.0 s; 1 workers
  Run time: 0.06 s
  There was an exception in popAvgRates():
    name 'Dict' is not defined
    (<class 'NameError'>, NameError("name 'Dict' is not defined"), <traceback object at 0x7f57b1e9fe00>)
```
This PR fixes this issue