### PR TITLE
Fix batch SGE example.

### DIFF
--- a/examples/batchSGE/README.md
+++ b/examples/batchSGE/README.md
@@ -35,7 +35,7 @@ simulation logs are generated in ~/qsub/
     b.runCfg = {'type': 'hpc_sge',
                 'jobName': 'my_batch',
                 'cores': 4,
-                'script': 'init.py',
+                'script': 'src/init.py',
                 'skip': True} 
 ```
 

--- a/examples/batchSGE/src/batch.py
+++ b/examples/batchSGE/src/batch.py
@@ -19,7 +19,7 @@ def batchTauWeight():
         b.runCfg = {'type': 'hpc_sge',
                     'jobName': 'my_batch',
                     'cores': 4,
-                    'script': 'init.py',
+                    'script': 'src/init.py',
                     'skip': True}
 
         # Run batch simulations

--- a/netpyne/batch/grid.py
+++ b/netpyne/batch/grid.py
@@ -326,7 +326,8 @@ def gridSubmit(batch, pc, netParamsSavePath, jobName, simLabel, processes, proce
             'vmem': '32G',
             'queueName': 'cpu.q',
             'cores': 2,
-            'pre': '', 'post': '',
+            'pre': 'source ~/.bashrc',
+            'post': '',
             'mpiCommand': 'mpiexec',
             #'log': "~/qsub/{}".format(jobName)
             'log': "{}/{}".format(os.getcwd(), jobName)
@@ -335,8 +336,9 @@ def gridSubmit(batch, pc, netParamsSavePath, jobName, simLabel, processes, proce
         sge_args.update(batch.runCfg)
 
         #(batch, pc, netParamsSavePath, jobName, simLabel, processes, processFiles):
-        sge_args['command'] = '%s -n $NSLOTS -hosts $(hostname) nrniv -python -mpi %s simConfig=%s netParams=%s' % (
+        sge_args['command'] = '%s -n %i nrniv -python -mpi %s simConfig=%s netParams=%s' % (
             sge_args['mpiCommand'],
+            sge_args['cores'],
             script,
             cfgSavePath,
             netParamsSavePath,

--- a/netpyne/batch/utils.py
+++ b/netpyne/batch/utils.py
@@ -107,7 +107,6 @@ def jobStringHPCSGE(jobName, walltime, vmem, queueName, cores, pre, command, pos
 #$ -o {log}.run
 #$ -e {log}.err
 {pre}
-source ~/.bashrc
 {command}
 {post}
         """


### PR DESCRIPTION
Remove the invalid `-hosts` argument in mpiexec.  I'm not sure if you need `$NSLOTS` or the `-host` arguments, but this worked for me on the Downstate HPC. 
A fix for #835 