### PR TITLE
remove the dummy section from plasticity/stdp creation of pointCell; …

### DIFF
--- a/netpyne/cell/pointCell.py
+++ b/netpyne/cell/pointCell.py
@@ -410,8 +410,7 @@ class PointCell(Cell):
 
                 # Add plasticity
                 if self.conns[-1].get('plast'):
-                    self.conns[-1]['dummySec'] = {'hObj': h.Section(name='dummySec', cell=self)}
-                    self._addConnPlasticity(self.conns[-1], self.conns[-1]['dummySec'], netcon, weightIndex)
+                    self._addConnPlasticity(self.conns[-1], None, netcon, weightIndex)
 
                 # Add time-dependent weight shaping
                 if 'shape' in params and params['shape']:
@@ -491,10 +490,12 @@ class PointCell(Cell):
 
         plasticity = params.get('plast')
         if plasticity and sim.cfg.createNEURONObj:
-            try:
-                plastMech = getattr(h, plasticity['mech'], None)(
-                    0, sec=sec['hObj']
-                )  # create plasticity mechanism (eg. h.STDP)
+            try:                
+                if sec is None:
+                    plastMech = getattr(h, plasticity['mech'], None)() # create plasticity mechanism (eg. h.STDP)
+                else:
+                    plastMech = getattr(h, plasticity['mech'], None)(0, sec=sec['hObj'])  # create plasticity mechanism (eg. h.STDP)                
+              
                 for plastParamName, plastParamValue in plasticity[
                     'params'
                 ].items():  # add params of the plasticity mechanism


### PR DESCRIPTION
…should do the same for compartCell

original implementation of STDP created a dummy section for each synapse the STDP mechanism was inserted into. this is a huge/wasteful overhead of order (n^2), where n is the # of plastic synapses. removing the Section speeds up STDP simulation considerably, particularly when using pointCells. 

making the same adjustment for compartCell will offer computational savings as well.