### PR TITLE
resolving SimConfig.save crash

### DIFF
--- a/netpyne/specs/simConfig.py
+++ b/netpyne/specs/simConfig.py
@@ -161,9 +161,10 @@ class SimConfig(object):
     def save(self, filename):
         import os
 
-        basename = os.path.basename(filename)
-        folder = filename.split(basename)[0]
-        ext = basename.split('.')[1]
+        folder = os.path.dirname(filename)
+        _, ext = os.path.splitext(filename)
+        if ext.startswith('.'):
+            ext = ext[1:]
 
         # make directories if they do not already exist: 
         try:


### PR DESCRIPTION

Hii @jchen6727 , I saw the issue here- SimConfig.save() crashes when provided with a simple filename (e.g., 'cfg.json') instead of a full absolute path.

As the crash in SimConfig.save() was happening because the original logic relied on finding a directory separator that isn't there for local filenames,here I used `os.path.splitext()` to handle the extension parsing instead. It safely grabs the extension even when there's no directory path provided, which was the main point of failure.

Did these 2 changes :
1. Switched to `os.path.dirname()` for the folder path.
2. Used `_, ext = os.path.splitext(filename)` to correctly unpack the root and extension.
