### PR TITLE
Docs: Conceal private setup methods (Issue #816)

### DIFF
--- a/netpyne/sim/__init__.py
+++ b/netpyne/sim/__init__.py
@@ -21,14 +21,14 @@ from neuron import h
 # import setup functions
 from .setup import (
     initialize,
-    setNet,
-    setNetParams,
-    setSimCfg,
-    createParallelContext,
+    _setNet,
+    _setNetParams,
+    _setSimCfg,
+    _createParallelContext,
     readCmdLineArgs,
     setupRecording,
-    setupRecordLFP,
-    setGlobals,
+    _setupRecordLFP,
+    _setGlobals,
 )
 
 # import run functions

--- a/netpyne/sim/gather.py
+++ b/netpyne/sim/gather.py
@@ -440,7 +440,7 @@ def gatherDataFromFiles(gatherLFP=True, saveFolder=None, simLabel=None, sim=None
                                 allPops[popLabel] = pop['tags']
 
                     if 'simConfig' in data.keys():
-                        setup.setSimCfg(data['simConfig'])
+                        setup._setSimCfg(data['simConfig'])
                     if 'net' in data and gatherLFP:
                         if 'recXElectrode' in data['net']:
                             xElectrode = data['net']['recXElectrode']

--- a/netpyne/sim/load.py
+++ b/netpyne/sim/load.py
@@ -158,7 +158,7 @@ def loadSimCfg(filename, data=None, variable='simConfig', setLoaded=True):
     if variable in data:
         rawSimConfig = data[variable]
         if setLoaded:
-            setup.setSimCfg(rawSimConfig)
+            setup._setSimCfg(rawSimConfig)
         else:
             return specs.SimConfig(rawSimConfig)
     else:
@@ -204,7 +204,7 @@ def loadNetParams(filename, data=None, variable=None, setLoaded=True):
         return
 
     if setLoaded:
-        setup.setNetParams(rawNetParams)
+        setup._setNetParams(rawNetParams)
     else:
         return specs.NetParams(rawNetParams)
 

--- a/netpyne/sim/run.py
+++ b/netpyne/sim/run.py
@@ -31,7 +31,7 @@ def preRun():
     sim.cvode.use_fast_imem(sim.cfg.use_fast_imem)
 
     # set h global params
-    sim.setGlobals()
+    sim._setGlobals()
 
     # set h.dt
     h.dt = sim.cfg.dt

--- a/netpyne/sim/setup.py
+++ b/netpyne/sim/setup.py
@@ -62,10 +62,10 @@ def initialize(netParams=None, simConfig=None, net=None):
     sim.nextHost = 0  # initialize next host
     sim.timingData = Dict()  # dict to store timing
 
-    sim.createParallelContext()  # inititalize PC, nhosts and rank
+    sim._createParallelContext()  # inititalize PC, nhosts and rank
     sim.cvode = h.CVode()
 
-    sim.setSimCfg(simConfig)  # set simulation configuration
+    sim._setSimCfg(simConfig)  # set simulation configuration
 
     # for testing validation
     # if simConfig.exitOnError:
@@ -80,11 +80,11 @@ def initialize(netParams=None, simConfig=None, net=None):
         sim.timing('start', 'totalTime')
 
     if net:
-        sim.setNet(net)  # set existing external network
+        sim._setNet(net)  # set existing external network
     else:
-        sim.setNet(sim.Network())  # or create new network
+        sim._setNet(sim.Network())  # or create new network
 
-    sim.setNetParams(netParams)  # set network parameters
+    sim._setNetParams(netParams)  # set network parameters
 
     if sim.nhosts > 1:
         sim.cfg.validateNetParams = False  # turn of error chceking if using multiple cores
@@ -113,9 +113,9 @@ def initialize(netParams=None, simConfig=None, net=None):
 # ------------------------------------------------------------------------------
 # Set network object to use in simulation
 # ------------------------------------------------------------------------------
-def setNet(net):
+def _setNet(net):
     """
-    Function for/to <short description of `netpyne.sim.setup.setNet`>
+    Function for/to <short description of `netpyne.sim.setup._setNet`>
 
     Parameters
     ----------
@@ -134,9 +134,9 @@ def setNet(net):
 # ------------------------------------------------------------------------------
 # Set network params to use in simulation
 # ------------------------------------------------------------------------------
-def setNetParams(params):
+def _setNetParams(params):
     """
-    Function for/to <short description of `netpyne.sim.setup.setNetParams`>
+    Function for/to <short description of `netpyne.sim.setup._setNetParams`>
 
     Parameters
     ----------
@@ -150,7 +150,7 @@ def setNetParams(params):
     from .. import sim
 
     if not hasattr(sim, 'net'):
-        sim.setNet(sim.Network())  # create new network if one doesn't exist
+        sim._setNet(sim.Network())  # create new network if one doesn't exist
 
     if params and isinstance(params, specs.NetParams):
         paramsDict = utils.replaceKeys(params.todict(), 'popLabel', 'pop')  # for backward compatibility
@@ -171,9 +171,9 @@ def setNetParams(params):
 # ------------------------------------------------------------------------------
 # Set simulation config
 # ------------------------------------------------------------------------------
-def setSimCfg(cfg):
+def _setSimCfg(cfg):
     """
-    Function for/to <short description of `netpyne.sim.setup.setSimCfg`>
+    Function for/to <short description of `netpyne.sim.setup._setSimCfg`>
 
     Parameters
     ----------
@@ -207,9 +207,9 @@ def setSimCfg(cfg):
 # ------------------------------------------------------------------------------
 # Create parallel context
 # ------------------------------------------------------------------------------
-def createParallelContext():
+def _createParallelContext():
     """
-    Function for/to <short description of `netpyne.sim.setup.createParallelContext`>
+    Function for/to <short description of `netpyne.sim.setup._createParallelContext`>
 
 
     """
@@ -306,9 +306,9 @@ def readCmdLineArgs(simConfigDefault='cfg.py', netParamsDefault='netParams.py'):
 # ------------------------------------------------------------------------------
 # Setup LFP Recording
 # ------------------------------------------------------------------------------
-def setupRecordLFP():
+def _setupRecordLFP():
     """
-    Function for/to <short description of `netpyne.sim.setup.setupRecordLFP`>
+    Function for/to <short description of `netpyne.sim.setup._setupRecordLFP`>
 
 
     """
@@ -380,9 +380,9 @@ def setupRecordLFP():
 # ------------------------------------------------------------------------------
 # Setup Dipoles Recording (needed for EEG/MEG)
 # ------------------------------------------------------------------------------
-def setupRecordDipole():
+def _setupRecordDipole():
     """
-    Function for/to <short description of `netpyne.sim.setup.setupRecordDipole`>
+    Function for/to <short description of `netpyne.sim.setup._setupRecordDipole`>
 
 
     """
@@ -435,7 +435,7 @@ def setupRecordDipole():
             cdm = lfpykit.CurrentDipoleMoment(cell=lfpykitCell)
             cell.M = cdm.get_transformation_matrix()
 
-            # set up recording of membrane currents (duplicate with setupRecordLFP -- unifiy and avoid calling twice)
+            # set up recording of membrane currents (duplicate with _setupRecordLFP -- unifiy and avoid calling twice)
             nseg = cell.getNumberOfSegments()
             cell.imembPtr = h.PtrVector(nseg)  # pointer vector
             if neuron_version < '9.0.0':
@@ -559,11 +559,11 @@ def setupRecording():
 
     # set LFP recording
     if sim.cfg.recordLFP or sim.cfg.saveIMembrane:
-        setupRecordLFP()
+        _setupRecordLFP()
 
     # set dipole recording
     if sim.cfg.recordDipole:
-        setupRecordDipole()
+        _setupRecordDipole()
 
     sim.timing('stop', 'setrecordTime')
 
@@ -573,9 +573,9 @@ def setupRecording():
 # ------------------------------------------------------------------------------
 # Get cells list for recording based on set of conditions
 # ------------------------------------------------------------------------------
-def setGlobals():
+def _setGlobals():
     """
-    Function for/to <short description of `netpyne.sim.setup.setGlobals`>
+    Function for/to <short description of `netpyne.sim.setup._setGlobals`>
 
 
     """

--- a/netpyne/sim/wrappers.py
+++ b/netpyne/sim/wrappers.py
@@ -428,7 +428,7 @@ def load(
         sim.cfg.createNEURONObj = createNEURONObj
         sim.loadAll(filename, instantiate=instantiate, createNEURONObj=createNEURONObj)
         if simConfig:
-            sim.setSimCfg(simConfig)  # set after to replace potentially loaded cfg
+            sim._setSimCfg(simConfig)  # set after to replace potentially loaded cfg
 
     if len(sim.net.cells) == 0 and instantiate:
         pops = sim.net.createPops()  # instantiate network populations


### PR DESCRIPTION
### Motivation
This PR addresses **Issue #816**. The auto-generated documentation for \`netpyne.sim\` currently exposes several internal "plumbing" methods (e.g., \`setNet\`, \`setNetParams\`) that are intended to be called only by \`initialize()\`. Exposing these confuses users who might try to call them manually.

### Changes
I have renamed the following internal methods in \`netpyne/sim/setup.py\` by adding a leading underscore (\`_\`), which causes Sphinx to exclude them from the public API docs:

* \`setNet\` → \`_setNet\`
* \`setNetParams\` → \`_setNetParams\`
* \`setSimCfg\` → \`_setSimCfg\`
* \`createParallelContext\` → \`_createParallelContext\`
* \`setGlobals\` → \`_setGlobals\`
* \`setupRecordLFP\` → \`_setupRecordLFP\`
* \`setupRecordDipole\` → \`_setupRecordDipole\`

### Verification
* **Internal Consistency:** Updated all internal calls to these methods in \`netpyne/sim/__init__.py\`, \`wrappers.py\`, \`load.py\`, and \`gather.py\`.
* **Safety Check:** Verified via \`grep\` that these methods are not used in \`tutorials/\` or \`examples/\`.
* **Docs Build:** Built the documentation locally; confirmed these methods no longer appear in the "Package Reference" section.